### PR TITLE
add debug macro and swap existing print macros with it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ authors = ["Vince van Oosten <vince@vince.lol>"]
 version = "^2.0"
 features = ["regexp", "verbose-errors"]
 
+[features]
+default = []
+
+debug = []

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate maillurgy;
 
 use maillurgy::socket;
@@ -8,5 +9,5 @@ use maillurgy::smtp::server::server as smtp_server;
 fn main() {
 
   let p = socket::start(smtp_server);
-  println!("main end: {:?}", p);
+  dbugln!("main end: {:?}", p);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,24 @@
 #[macro_use]
 extern crate nom;
 
+#[macro_export]
+macro_rules! dbug {
+    ($($arg:tt)*) => (#[cfg(any(test, feature = "debug"))] print!($($arg)*));
+}
+
+#[macro_export]
+macro_rules! dbugln {
+    ($($arg:tt)*) => (#[cfg(any(test, feature = "debug"))] println!($($arg)*));
+}
+
 pub mod socket;
 pub mod smtp;
+
+
+#[test]
+fn maco_test() {
+    dbug!("debug!!!!!! {}\n", 4);
+    dbug!("debug!!!!!! {:?}\n", 5);
+    dbugln!("debug!!!!!! {}\n", 6);
+    dbugln!("debug!!!!!! {:?}\n", 7);
+}

--- a/src/smtp/parse/testhelper.rs
+++ b/src/smtp/parse/testhelper.rs
@@ -17,15 +17,15 @@ where T: Eq,
 
     let mut index = 0;
     for test in testcases {
-        println!("\nStarting test {}", index);
+        dbugln!("\nStarting test {}", index);
         let ref input = test.0;
         let ref expected_result = test.1;
 
-        println!("input : {:?}", String::from_utf8_lossy(input));
-        println!("expect: {:?}", &expected_result);
+        dbugln!("input : {:?}", String::from_utf8_lossy(input));
+        dbugln!("expect: {:?}", &expected_result);
 
         let result = test_parser(input);
-        println!("actual: {:?}", result);
+        dbugln!("actual: {:?}", result);
 
         assert_eq!(result, *expected_result);
         index += 1;

--- a/src/smtp/server.rs
+++ b/src/smtp/server.rs
@@ -7,7 +7,7 @@ pub fn server(mut stream: & TcpStream) {
     let unrecognised_command_message = b"500 Command not recognized";
     let _ = stream.write(closed_message);
     let _ = stream.flush();
-    println!("welcome message printed");
+    dbugln!("welcome message printed");
 
     let mut buf = [0; 2048];
 
@@ -18,27 +18,27 @@ pub fn server(mut stream: & TcpStream) {
             Ok(buflen) => handle_buffer(&buf[..buflen]),
 
             // TODO: maybe return an Err(e) here?
-            Err(e) => {println!("buf err: {}", e); false},
+            Err(e) => {dbugln!("buf err: {}", e); false},
         };
 
         if cont {
             let _ = stream.write_all(unrecognised_command_message);
         } else {
-            println!("break");
+            dbugln!("break");
             break
         }
     }
-    println!("shutdown");
+    dbugln!("shutdown");
     let _ = stream.shutdown(Shutdown::Both);
 }
 
 fn handle_buffer(buffer: &[u8]) -> bool {
 
-    println!("{:?}", &buffer);
+    dbugln!("{:?}", &buffer);
     let a = super::parse::commands::end_of_transmission(buffer);
-    println!("{:?}", a);
+    dbugln!("{:?}", a);
     if a.is_done() {
-        println!("quitting");
+        dbugln!("quitting");
         return false
     }
     true
@@ -64,9 +64,9 @@ mod tests {
         let client = TcpListener::bind("127.0.0.2:20244").unwrap();
 
         let stream = TcpStream::connect("127.0.0.2:20244").unwrap();
-        println!("{:?}",stream);
+        dbugln!("{:?}",stream);
         let (mut connection, _) = client.accept().unwrap();
-        println!("{:?}", connection);
+        dbugln!("{:?}", connection);
 
         let client_thread = thread::spawn(move || {
             use std::time::Duration;
@@ -85,7 +85,7 @@ mod tests {
         server(&stream);
 
         let res = client_thread.join();
-        println!("join result {:?}", res);
+        dbugln!("join result {:?}", res);
     }
 
     #[test]


### PR DESCRIPTION
adds debug versions of `print!` and `println!` named `dbug(ln)!` that only compile on `cargo test` or on `cargo run --features debug`